### PR TITLE
Removed initial whitespace in edinburgh - Copy.txt

### DIFF
--- a/edinburgh - Copy.txt
+++ b/edinburgh - Copy.txt
@@ -1,5 +1,3 @@
-
-
 Edinburgh
 From Wikipedia, the free encyclopedia
 Jump to navigationJump to search


### PR DESCRIPTION
There was some terrible whitespace at the start of edinburgh - Copy.txt.  I've removed it.